### PR TITLE
Exclude bot PRs from Claude review

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,8 +27,7 @@ jobs:
     if: >
       github.event_name == 'pull_request'
       && (! github.event.pull_request.draft)
-      && (! startsWith(github.head_ref, 'dependabot/'))
-      && (! startsWith(github.head_ref, 'renovate/'))
+      && github.event.pull_request.user.type != 'Bot'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- skip the Claude review job for PRs authored by GitHub bots
- replace Dependabot/Renovate branch-name checks with the generic PR author type check

## Why
Claude Code rejects bot-initiated review workflows unless the bot is allowlisted. Filtering bot-authored PRs at the job condition avoids failed review runs from release and dependency automation while simplifying the trigger logic.

## Validation
- review job now requires `github.event.pull_request.user.type != 'Bot'`
- existing draft PR guard is unchanged
- mention-triggered Claude bot job is unchanged